### PR TITLE
fix(ci): move Test job to a GitHub-hosted runner (fork-PR RCE on self-hosted)

### DIFF
--- a/.github/workflows/controller.yml
+++ b/.github/workflows/controller.yml
@@ -12,8 +12,31 @@ on:
       - main
 
 jobs:
+  # ── SECURITY: this job MUST stay on a GitHub-hosted runner. ──────────────────────────────
+  # This is a PUBLIC repository and this job is reachable by `pull_request` from ANY fork
+  # (see the trigger above). It was previously `runs-on: self-hosted-linux` with no job-level
+  # guard, which meant `make test` -> `go test ./...` executed attacker-authored test code on
+  # our self-hosted ARC runner — a runner with privileged dind, `sudo`, a shared /cache
+  # hostPath holding GOCACHE/GOMODCACHE (so poisoning it runs attacker code in later,
+  # unrelated builds across two GitHub orgs), node-level Harbor pull credentials, and network
+  # reach to Vault, Harbor, Athens and the Kubernetes API.
+  #
+  # Moving to a hosted runner rather than adding the sibling jobs'
+  # `if: github.event_name != 'pull_request'` guard is DELIBERATE: that guard would close the
+  # hole by disabling PR testing entirely, which is a real loss for a public repo that accepts
+  # outside contributions. Hosted keeps full PR coverage AND costs nothing — GitHub-hosted
+  # standard runners have unlimited free minutes on public repositories.
+  #
+  # Safe to run hosted: verified 2026-08-14 that go.mod has ZERO private-org requires and ZERO
+  # replace directives, so `go mod download` resolves entirely from proxy.golang.org and needs
+  # no Athens/LAN access. `setup-kubectl` only installs the binary; nothing here talks to a
+  # cluster. If a private dependency is ever added, do NOT move this back to self-hosted —
+  # split the private part into a separate, fork-guarded job instead.
+  #
+  # Build / Publish / Release below stay on self-hosted: they are guarded to non-PR events and
+  # genuinely need Harbor. Refs: cluster-services-517.
   Test:
-    runs-on: self-hosted-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## What

Moves the `Test` job from `self-hosted-linux` to `ubuntu-latest`. One line changed, plus a comment explaining why it must stay that way.

## Why

This is a **public** repository, and `Test` was reachable by `pull_request` from **any fork** with **no job-level guard**, running on our self-hosted ARC runner.

`make test` is `go test ./...` — so a fork PR executed **attacker-authored test code** on a runner that has:

- privileged dind and `sudo`
- the shared `/cache` hostPath holding `GOCACHE`/`GOMODCACHE` — poisoning it runs attacker code in **later, unrelated builds across two GitHub orgs**
- node-level Harbor pull credentials
- network reach to Vault, Harbor, Athens and the Kubernetes API

The sibling jobs were already safe — `Build` and `Publish` carry `if: github.event_name != 'pull_request'`, `Release` is tag-gated. Only `Test` was unguarded, so the file was internally inconsistent.

## Why hosted instead of adding the same guard

Adding `if: github.event_name != 'pull_request'` would close the hole by **disabling PR testing entirely** — a real loss for a public repo that accepts outside contributions.

Moving to a hosted runner keeps full PR coverage **and costs nothing**: GitHub-hosted standard runners have unlimited free minutes on public repositories.

## Verified safe to run hosted, before making the change

- `go.mod` has **0 private-org requires** and **0 replace directives** → `go mod download` resolves entirely from `proxy.golang.org`, no Athens/LAN needed
- No Vault, Harbor or cluster access in the job; `azure/setup-kubectl` only installs the binary
- Every step runs on a stock `ubuntu-latest` image

## Negative check after the change

No job is both `pull_request`-reachable **and** self-hosted without a guard:

| Job | Runner | Guard |
|---|---|---|
| `Test` | **ubuntu-latest** | none needed |
| `Build` | self-hosted-linux | `github.event_name != 'pull_request'` |
| `Publish` | self-hosted-linux | `github.event_name != 'pull_request'` |
| `Release` | self-hosted-linux | `startsWith(github.ref, 'refs/tags/v')` |

## This PR is its own test

It triggers `on: pull_request`, so **the `Test` run on this PR is the live proof** that the job works on a hosted runner. Merge once it's green.

## Note for the future

If a private dependency is ever added here, do **not** move this back to self-hosted — split the private part into a separate, fork-guarded job. There's a comment on the job saying so.

Refs: `cluster-services-517`

https://claude.ai/code/session_01PYjZywQworVe5gurTn1J5D
